### PR TITLE
update default index type from `IVFFLAT` to `MSTG`

### DIFF
--- a/llama_index/vector_stores/myscale.py
+++ b/llama_index/vector_stores/myscale.py
@@ -63,7 +63,7 @@ class MyScaleVectorStore(VectorStore):
         myscale_client: Optional[Any] = None,
         table: str = "llama_index",
         database: str = "default",
-        index_type: str = "IVFFLAT",
+        index_type: str = "MSTG",
         metric: str = "cosine",
         batch_size: int = 32,
         index_params: Optional[dict] = None,


### PR DESCRIPTION
# Description

We update the default index type from IVFFLAT to MSTG, a new vector type developed by MyScale.

## Type of Change

minor change on configuration

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

minor change on configuration

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
